### PR TITLE
Add DWF blocks for the RubySec project and for HackerOne

### DIFF
--- a/DNA-Registry.csv
+++ b/DNA-Registry.csv
@@ -8,6 +8,7 @@
 "Darius Freamon","darius.freamon@gmail.com","darius.freamon@gmail.com","https://dariusfreamon.wordpress.com/","DWF-YEAR-78000","DWF-YEAR-78999"
 "Reed Loden","reed@reedloden.com","reed@reedloden.com","Various","DWF-YEAR-79000","DWF-YEAR-79999"
 "Kurt Seifried","kurt@seifried.org","kurt@seifried.org","http://www.seifried.org/","DWF-YEAR-80000","DWF-YEAR-80999"
+"RubySec","info@rubysec.com","reed@reedloden.com,phillmv@state.io,maxim@ontoillogical.com,postmodern.mod3@gmail.com","http://rubysec.com/","DWF-YEAR-81000","DWF-YEAR-81999"
 "Tenable","vulnreport@tenable.com","vulnreport@tenable.com","http://www.tenable.com/security/","DWF-YEAR-82000","DWF-YEAR-82999"
 "Adam Caudill","adam@adamcaudill.com","adam@adamcaudill.com","https://adamcaudill.com/","DWF-YEAR-83000","DWF-YEAR-83999"
 "Shubham Shah","admin@shubh.am","admin@shubh.am","https://shubh.am/","DWF-YEAR-84000","DWF-YEAR-84999"
@@ -24,4 +25,5 @@
 "OpenSwitch Security Team","security@openswitch.net","security@openswitch.net","http://openswitch.net/","DWF-YEAR-95000","DWF-YEAR-95999"
 "Unify Product Security Team (OpenScape Baseline Security Office)","obso@unify.com","obso@unify.com","https://www.unify.com/security/advisories","DWF-YEAR-96000","DWF-YEAR-96999"
 "rpm5.org","jbj@rpm5.org","jbj@rpm5.org","http://rpm5.org","DWF-YEAR-97000","DWF-YEAR-97999"
+"HackerOne","support@hackerone.com","reed@hackerone.com,adam@hackerone.com,arice@hackerone.com","https://hackerone.com/","DWF-YEAR-98000","DWF-YEAR-98999"
 "CERT/CC","cert@cert.org","cert@cert.org,amanion@cert.org","http://www.kb.cert.org/vuls","DWF-YEAR-98000","DWF-YEAR-127999"


### PR DESCRIPTION
RubySec -- Will assign DWF IDs to vulnerabilities affecting Ruby-related things (https://github.com/rubysec/ruby-advisory-db/issues/224)
HackerOne -- Third-party vulnerability coordinator that will assign DWF IDs to customers or researchers as needed for vulnerabilities